### PR TITLE
Add support for getting/setting GPIOs

### DIFF
--- a/src/cy_serial_bridge/driver.py
+++ b/src/cy_serial_bridge/driver.py
@@ -380,7 +380,9 @@ class CySerBridgeBase:
 
     def is_gpio_input(self, gpio_nr: int) -> bool:
         """
-        Check if a GPIO pin is in input mode.
+        Check if a GPIO pin is readable.
+        We can read the value of input or output pins, but
+        not if they are tristated or in some other mode.
 
         :param pin: GPIO pin number to check
         :return: True if the pin is an input pin, False otherwise
@@ -412,13 +414,11 @@ class CySerBridgeBase:
                 timeout=self.timeout
             )
         # TODO check for errors
-        
+
         
     def get_gpio(self, gpio_nr: int) -> int:
         """
         Get the value of a GPIO pin.
-        TODO can we also read the value of output pins? if not, we should add a method to read the initial state of the pin
-
         :param pin: GPIO pin number to get
         :return: Value of the pin
         """

--- a/src/cy_serial_bridge/usb_constants.py
+++ b/src/cy_serial_bridge/usb_constants.py
@@ -86,8 +86,13 @@ class CyVendorCmds(IntEnum):
     CY_JTAG_READ_CMD = 0xD2
     CY_JTAG_WRITE_CMD = 0xD3
 
+    # From Infineon's forums on Mar 24, 2023, here: https://community.infineon.com/t5/USB-low-full-high-speed/CY7C65215-Get-Set-GPIO-Config/td-p/336658
+    #    "CY_GPIO_GET_CONFIG_CMD is maintaining in CyUSBCommon.h but it has not been implemented at the
+    #     hoist side and Silicon so this will not work, we apologize for the confusion with this code 
+    #     will remove this in the upcoming release so it does not create confusion to the user."
     CY_GPIO_GET_CONFIG_CMD = 0xD8
     CY_GPIO_SET_CONFIG_CMD = 0xD9
+    # GET_VALUE and SET_VALUE are implemented and can be used
     CY_GPIO_GET_VALUE_CMD = 0xDA
     CY_GPIO_SET_VALUE_CMD = 0xDB
 
@@ -191,7 +196,8 @@ CY_FIRMWARE_BREAKUP_SIZE = 4096
 CY_GET_SILICON_ID_LEN = 4
 CY_GET_FIRMWARE_VERSION_LEN = 8
 CY_GET_SIGNATURE_LEN = 4
-
+CY_GET_GPIO_LEN = 2
+CY_SET_GPIO_LEN = 1
 
 # PHDC related macros
 class CyPhdc(IntEnum):


### PR DESCRIPTION
The CY7C652xx also support GPIOs. 

The chip is quite flexible, allowing any of the pins not used for other functions to be used as GPIOs. You have to decide at configuration time whether the pin should be input or output, and for output pins you can set what the initial output state is after reset.

Having GPIO control is useful in one of this chips primary use-cases: in system programming. Having GPIO control allows you to trigger reset pins, set mode pins, check "done" pins and similar things that you need when flashing FPGAs and other devices.

This PR adds support for setting the GPIOs programmatically in the python API.

Please let me know if this meets your expectations? I'm not primarily a python programmer, so please be forgiving! 😃 

It is the first PR but I hope to send you one or two more:

- I'd like to add GPIO setting to the CLI tool also
- I'm using the CY7C65215 - which is the dual channel model. I'd like to add support for it.