### PR TITLE
Add support for scanning dual-channel devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Additionally, I assume that it would be possible to brick your CY7C652xx by load
 - CapSense
 - GPIO
 - JTAG (only supported on the larger dual channel devices)
-- Scanning & discovering dual channel CY7C652xx devices (e.g. CY7C65215)
+- Configuring dual channel CY7C652xx devices (e.g. CY7C65215)
 
 ## Using the Command-Line Interface
 
@@ -301,7 +301,9 @@ Also note that adding `--randomize-serno` or `--set-serno` can be added to the r
 
 Another issue: On Windows, if you have a given VID and PID assigned to use the WinUSB driver via Zadig, Windows will not try and use the USB CDC driver to enumerate COM ports from the device.  This means that a device in SPI/I2C mode cannot use the same VID and PID as a device in UART CDC mode.  To solve this, this driver automatically uses two PIDs for each device.  The even PID is used in SPI/I2C mode, and the odd PID is used in UART CDC mode.
 
-WARNING: This setup is for dev testing only!  If you plan to use this driver in a real product, this strategy will not be usable, this VID space is owned by Cypress.  You will have to purchase a VID and two consecutive PID values for yourself.
+For dual-channel devices, this is extended to four VIDs/PIDs: one for both in non-UART mode, one for SCB 0 in UART mode, one for SCB 1 in UART mode, and one for both SCBs in UART mode.
+
+WARNING: This setup is for dev testing only!  If you plan to use this driver in a real product, this strategy will not be usable, this VID space is owned by Cypress.  You will have to purchase a VID and several consecutive PID values for yourself.
 
 ## To Do List / Known Issues
 - If the I2C lines are not pulled up to 3.3V, I2C read and write bulk transfers hang forever and we don't have error handling for this

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,6 +153,8 @@ ignore = [
     'SIM102',  # Allow multiple nested if statements.  Sometimes it's nice for readability
     'UP031',   # Allow percent formatting, it can be useful sometimes!
     'PLC0414', # Allow 'import x as x', needed for exporting type names
+    'C901',    # Complexity
+    'PLR0912', # Too many branches
 ]
 exclude = ["stubs/*"]
 

--- a/rules/61-cy-serial-bridge.rules
+++ b/rules/61-cy-serial-bridge.rules
@@ -1,11 +1,11 @@
 # CY7C652xx USB-serial bridge chips, used with cy_serial_bridge driver.
 # This grants access to physically present users and users in the `plugdev` group.
 
-# This rule uses an even PID, so it's for SPI/I2C mode
+# Rules for default VID/PIDs used by this cy_serial_bridge, see README for info
 SUBSYSTEM=="usb", ATTRS{idVendor}=="04b4", ATTRS{idProduct}=="e010", GROUP="plugdev", TAG+="uaccess"
-
-# This rule uses an odd PID, so it's for UART CDC mode
 SUBSYSTEM=="usb", ATTRS{idVendor}=="04b4", ATTRS{idProduct}=="e011", GROUP="plugdev", TAG+="uaccess"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="04b4", ATTRS{idProduct}=="e012", GROUP="plugdev", TAG+="uaccess"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="04b4", ATTRS{idProduct}=="e013", GROUP="plugdev", TAG+="uaccess"
 
 # Also provide rules for factory-new devices with the default VID and PID
 # CY7C65211
@@ -14,6 +14,11 @@ SUBSYSTEM=="usb", ATTRS{idVendor}=="04b4", ATTRS{idProduct}=="0003", GROUP="plug
 SUBSYSTEM=="usb", ATTRS{idVendor}=="04b4", ATTRS{idProduct}=="0004", GROUP="plugdev", TAG+="uaccess"
 # CY7C65211A
 SUBSYSTEM=="usb", ATTRS{idVendor}=="04b4", ATTRS{idProduct}=="00fb", GROUP="plugdev", TAG+="uaccess"
+# CY7C65215
+SUBSYSTEM=="usb", ATTRS{idVendor}=="04b4", ATTRS{idProduct}=="0005", GROUP="plugdev", TAG+="uaccess"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="04b4", ATTRS{idProduct}=="0007", GROUP="plugdev", TAG+="uaccess"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="04b4", ATTRS{idProduct}=="0009", GROUP="plugdev", TAG+="uaccess"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="04b4", ATTRS{idProduct}=="000A", GROUP="plugdev", TAG+="uaccess"
 
 # This one grants access to the serial port tty
 SUBSYSTEM=="tty", ATTRS{idVendor}=="04b4", ATTRS{idProduct}=="e011", MODE="660", GROUP="plugdev", TAG+="uaccess", ENV{ID_MM_DEVICE_IGNORE}="1"

--- a/src/cy_serial_bridge/cli.py
+++ b/src/cy_serial_bridge/cli.py
@@ -340,19 +340,20 @@ def scan(scan_all: Annotated[bool, ScanAllOption] = False) -> None:
     else:
         print("Detected Devices:")
         for device in devices:
+            scb_str = f"[bold]SCB[/bold] {device.scb} " if device.is_dual_channel else ""
             rich.print(
-                f"- [bold yellow]{device.vid:04x}[/bold yellow]:[bold yellow]{device.pid:04x}[/bold yellow] ([bold]Type:[/bold] {device.curr_cytype.name})",
+                f"- [bold yellow]{device.vid:04x}[/bold yellow]:[bold yellow]{device.pid:04x}[/bold yellow] {scb_str}([bold]Type:[/bold] {device.curr_cytype.name})",
                 end="",
             )
 
             if device.open_failed:
                 if sys.platform == "win32":
                     rich.print(
-                        "[red]<Open failed, cannot get name, com port, or serno.  Attach WinUSB driver with Zadig!>[/red]"
+                        "[red]<Open failed, cannot get name, com port, or serno. Attach WinUSB driver with Zadig!>[/red]"
                     )
                 else:
                     rich.print(
-                        "[red]<Open failed, cannot get name, tty, or serial number.  Check udev rules and permissions.>[/red]"
+                        "[red]<Open failed, cannot get name, tty, or serial number. Check udev rules and permissions.>[/red]"
                     )
             else:
                 rich.print(

--- a/src/cy_serial_bridge/cy_scb_context.py
+++ b/src/cy_serial_bridge/cy_scb_context.py
@@ -64,14 +64,24 @@ class CyScbContext:
         Uses pyserial to do the hard work. If no device is found, returns None
         """
         serial_port_generator: Sequence[list_ports_common.ListPortInfo] = list_ports.comports()
+        matches = []
         for serial_port in serial_port_generator:
             if serial_port.serial_number is not None:
                 # Note: Testing on Windows, the serial number always gets converted to uppercase.
                 # So we have to lowercase both values before comparing them.
                 if serial_port.serial_number.lower() == serial_number.lower():
-                    return serial_port.device
+                    matches.append(serial_port.device)
 
-        return None
+        # If there was exactly one match, return it.
+        # I suspect that, if you have a dual channel device with both channels in CDC mode,
+        # this might produce multiple matches since both will be associated with that serial number
+        # (though, at least on my test machine, Windows can't seem to associate either channel with
+        # the serial number so you get no matches). If this does happen, also return None since an
+        # unambiguous matching isn't known.
+        if len(matches) == 1:
+            return matches[0]
+        else:
+            return None
 
     def list_devices(
         self,
@@ -84,10 +94,13 @@ class CyScbContext:
         If the vid and pid set is left at the default, only the driver default vid and pid will be used.
         If the vid and pid set is set to None, all devices which *could* be CY6C652xx chips are returned.
 
-        Note: For each PID value, both the even value (pid & 0xFFFE) and the odd value ((pid & 0xFFFE) + 1)
-        will be considered.  This is to support UART CDC mode (see the README)
+        Note: The lower 2 bits of the PID value will not be compared (always assumed to match).
+            This is to support UART CDC mode (see the README).
         """
         device_list: list[DiscoveredDevice] = []
+
+        pid_mask = 0xFFFC
+        vid_pids_to_search_for = {(vid, pid & pid_mask) for vid, pid in vid_pids} if vid_pids is not None else None
 
         # In my testing, on Windows, this is needed in order to correctly detect re-enumerated devices
         # in some cases.  Seems to be some sort of libusb bug...
@@ -97,10 +110,8 @@ class CyScbContext:
 
         dev: usb1.USBDevice
         for dev in self.usb_context.getDeviceIterator(skip_on_error=True):
-            even_vid_pid = (dev.getVendorID(), dev.getProductID() & 0xFFFE)
-            odd_vid_pid = (dev.getVendorID(), (dev.getProductID() & 0xFFFE) + 1)
-
-            if vid_pids is not None and even_vid_pid not in vid_pids and odd_vid_pid not in vid_pids:
+            vid_pid = (dev.getVendorID(), dev.getProductID() & pid_mask)
+            if vid_pids_to_search_for is not None and vid_pid not in vid_pids_to_search_for:
                 # Not a VID-PID we're looking for
                 continue
 
@@ -109,116 +120,136 @@ class CyScbContext:
                 continue
             cfg: usb1.USBConfiguration = dev[0]
 
-            # CY7C652xx devices always have either two or three interfaces: potentially one for the USB CDC COM port,
-            # one for the actual USB-serial bridge, and one for the configuration interface.
-            if cfg.getNumInterfaces() != 2 and cfg.getNumInterfaces() != 3:
+            # CY7C652xx devices always have between two and five configurations. A single-channel chip in
+            # SPI/I2C mode will have two (one for the vendor interface and one for the manufacturer interface).
+            # A dual-channel chip in UART mode will have five: two per COM port and the manufacturer interface).
+            if cfg.getNumInterfaces() < 2 or cfg.getNumInterfaces() > 5:
                 continue
 
-            usb_cdc_interface_settings: usb1.USBInterfaceSetting | None = None
-            cdc_data_interface_settings: usb1.USBInterfaceSetting | None = None
-            scb_interface_settings: usb1.USBInterfaceSetting | None = None
-            mfg_interface_settings: usb1.USBInterfaceSetting
+            # Does this look like a single or dual channel chip?
+            scb_0_looks_like_cdc = cfg[0][0].getClass() == USBClass.CDC
+            looks_like_dual_channel = cfg.getNumInterfaces() > 3 if scb_0_looks_like_cdc else cfg.getNumInterfaces() > 2
 
-            if cfg.getNumInterfaces() == 3 and cfg[0][0].getClass() == USBClass.CDC:
-                # USB CDC mode
-                usb_cdc_interface_settings = cfg[0][0]
-                cdc_data_interface_settings = cfg[1][0]
-                mfg_interface_settings = cfg[2][0]
-
-                # Check USB CDC interface
-                if usb_cdc_interface_settings.getSubClass() != 0x2:
-                    continue
-
-                # Check CDC Data interface
-                if cdc_data_interface_settings.getClass() != 0x0A or cdc_data_interface_settings.getSubClass() != 0x0:
-                    continue
-
-                curr_cytype = CyType.UART_CDC
-
-            else:
-                # USB vendor mode
-                scb_interface_settings = cfg[0][0]
-                mfg_interface_settings = cfg[1][0]
-
-                # Check SCB interface -- the Class should be 0xFF (vendor defined/no rules)
-                # and the SubClass value gives the CyType
-                if scb_interface_settings.getClass() != USBClass.VENDOR:
-                    continue
-                if scb_interface_settings.getSubClass() not in {
-                    CyType.UART_VENDOR.value,
-                    CyType.SPI.value,
-                    CyType.I2C.value,
-                }:
-                    continue
-
-                # Check SCB endpoints
-                if scb_interface_settings.getNumEndpoints() != 3:
-                    continue
-                # Bulk host-to-dev endpoint
-                if (
-                    scb_interface_settings[0].getAddress() != 0x01
-                    or (scb_interface_settings[0].getAttributes() & 0x3) != 2
-                ):
-                    continue
-                # Bulk dev-to-host endpoint
-                if (
-                    scb_interface_settings[1].getAddress() != 0x82
-                    or (scb_interface_settings[1].getAttributes() & 0x3) != 2
-                ):
-                    continue
-                # Interrupt dev-to-host endpoint
-                if (
-                    scb_interface_settings[2].getAddress() != 0x83
-                    or (scb_interface_settings[2].getAttributes() & 0x3) != 3
-                ):
-                    continue
-
-                curr_cytype = CyType(scb_interface_settings.getSubClass())
-
-            # Check manufacturer interface.
-            # It has a defined class/subclass and has no endpoints
-            if mfg_interface_settings.getClass() != 0xFF:
-                continue
-            if mfg_interface_settings.getSubClass() != CyType.MFG:
-                continue
-            if mfg_interface_settings.getNumEndpoints() != 0:
-                continue
-
-            # If we got all the way here, it looks like a CY6C652xx device!
-            # Record attributes and add it to the list
-            list_entry = DiscoveredDevice(
-                usb_device=dev,
-                usb_configuration=cfg,
-                mfg_interface_settings=mfg_interface_settings,
-                scb_interface_settings=scb_interface_settings,
-                usb_cdc_interface_settings=usb_cdc_interface_settings,
-                cdc_data_interface_settings=cdc_data_interface_settings,
-                vid=dev.getVendorID(),
-                pid=dev.getProductID(),
-                curr_cytype=curr_cytype,
-                open_failed=False,
-            )
-            try:
-                opened_device = dev.open()
-                list_entry.manufacturer_str = opened_device.getManufacturer()
-                list_entry.product_str = opened_device.getProduct()
-                list_entry.serial_number = opened_device.getSerialNumber()
-            except usb1.USBError:
-                list_entry.open_failed = True
-
-            # Iff this is a CDC serial device, find its associated COM port.
-            # Luckily, pyserial does the hard work of talking to the OS for us here.
-            if curr_cytype == CyType.UART_CDC and not list_entry.open_failed:
-                if list_entry.serial_number is None:
-                    log.warning(
-                        "Discovered CY7C652xx device in UART mode with no serial number configured.  Will "
-                        "not be able to open a terminal to this device until it is configured with a "
-                        "serial number."
-                    )
+            for scb_idx in range(2 if looks_like_dual_channel else 1):
+                # Which interface do we start looking at?
+                if scb_idx == 0:
+                    first_interface_idx = 0
+                elif scb_0_looks_like_cdc:
+                    first_interface_idx = 2
                 else:
-                    list_entry.serial_port_name = self._find_serial_port_name_for_serno(list_entry.serial_number)
+                    first_interface_idx = 1
 
-            device_list.append(list_entry)
+                usb_cdc_interface_settings: usb1.USBInterfaceSetting | None = None
+                cdc_data_interface_settings: usb1.USBInterfaceSetting | None = None
+                scb_interface_settings: usb1.USBInterfaceSetting | None = None
+                mfg_interface_settings: usb1.USBInterfaceSetting
+
+                if cfg[first_interface_idx][0].getClass() == USBClass.CDC:
+                    # USB CDC mode
+                    usb_cdc_interface_settings = cfg[first_interface_idx][0]
+                    cdc_data_interface_settings = cfg[first_interface_idx + 1][0]
+                    mfg_interface_settings = cfg[cfg.getNumInterfaces() - 1][0]
+
+                    # Check USB CDC interface
+                    if usb_cdc_interface_settings.getSubClass() != 0x2:
+                        continue
+
+                    # Check CDC Data interface
+                    if (
+                        cdc_data_interface_settings.getClass() != 0x0A
+                        or cdc_data_interface_settings.getSubClass() != 0x0
+                    ):
+                        continue
+
+                    curr_cytype = CyType.UART_CDC
+
+                else:
+                    # USB vendor mode
+                    scb_interface_settings = cfg[first_interface_idx][0]
+                    mfg_interface_settings = cfg[cfg.getNumInterfaces() - 1][0]
+
+                    # Check SCB interface -- the Class should be 0xFF (vendor defined/no rules)
+                    # and the SubClass value gives the CyType
+                    if scb_interface_settings.getClass() != USBClass.VENDOR:
+                        continue
+                    if scb_interface_settings.getSubClass() not in {
+                        CyType.UART_VENDOR.value,
+                        CyType.SPI.value,
+                        CyType.I2C.value,
+                    }:
+                        continue
+
+                    # Check SCB endpoints
+                    if scb_interface_settings.getNumEndpoints() != 3:
+                        continue
+                    # Bulk host-to-dev endpoint
+                    if (
+                        scb_interface_settings[0].getAddress() != (0x01 if scb_idx == 0 else 0x04)
+                        or (scb_interface_settings[0].getAttributes() & 0x3) != 2
+                    ):
+                        continue
+                    # Bulk dev-to-host endpoint
+                    if (
+                        scb_interface_settings[1].getAddress() != (0x82 if scb_idx == 0 else 0x85)
+                        or (scb_interface_settings[1].getAttributes() & 0x3) != 2
+                    ):
+                        continue
+                    # Interrupt dev-to-host endpoint
+                    if (
+                        scb_interface_settings[2].getAddress() != (0x83 if scb_idx == 0 else 0x86)
+                        or (scb_interface_settings[2].getAttributes() & 0x3) != 3
+                    ):
+                        continue
+
+                    curr_cytype = CyType(scb_interface_settings.getSubClass())
+
+                # Check manufacturer interface.
+                # It has a defined class/subclass and has no endpoints
+                if mfg_interface_settings.getClass() != 0xFF:
+                    continue
+                if mfg_interface_settings.getSubClass() != CyType.MFG:
+                    continue
+                if mfg_interface_settings.getNumEndpoints() != 0:
+                    continue
+
+                # If we got all the way here, it looks like a CY6C652xx device!
+                # Record attributes and add it to the list
+                list_entry = DiscoveredDevice(
+                    usb_device=dev,
+                    usb_configuration=cfg,
+                    mfg_interface_settings=mfg_interface_settings,
+                    scb_interface_settings=scb_interface_settings,
+                    usb_cdc_interface_settings=usb_cdc_interface_settings,
+                    cdc_data_interface_settings=cdc_data_interface_settings,
+                    vid=dev.getVendorID(),
+                    pid=dev.getProductID(),
+                    scb=scb_idx,
+                    is_dual_channel=looks_like_dual_channel,
+                    curr_cytype=curr_cytype,
+                    open_failed=False,
+                )
+                try:
+                    opened_device = dev.open()
+                    list_entry.manufacturer_str = opened_device.getManufacturer()
+                    list_entry.product_str = opened_device.getProduct()
+                    list_entry.serial_number = opened_device.getSerialNumber()
+                    opened_device.close()
+                except usb1.USBError:
+                    list_entry.open_failed = True
+
+                # Iff this is a CDC serial device, find its associated COM port.
+                # Luckily, pyserial does the hard work of talking to the OS for us here.
+                if curr_cytype == CyType.UART_CDC and not list_entry.open_failed:
+                    if list_entry.serial_number is None:
+                        log.warning(
+                            "Discovered CY7C652xx device in UART mode with no serial number configured.  Will "
+                            "not be able to open a terminal to this device until it is configured with a "
+                            "serial number."
+                        )
+                    else:
+                        list_entry.serial_port_name = self._find_serial_port_name_for_serno(list_entry.serial_number)
+
+                device_list.append(list_entry)
 
         return device_list
 

--- a/src/cy_serial_bridge/driver.py
+++ b/src/cy_serial_bridge/driver.py
@@ -422,6 +422,10 @@ class CyMfgrIface(CySerBridgeBase):
         :param scb_index: Index of the SCB to open, for multi-port devices
         :param timeout: Timeout to use for USB operations in milliseconds
         """
+        if discovered_dev.is_dual_channel:
+            message = "Reconfiguring dual-channel devices not implemented yet."
+            raise NotImplementedError(message)
+
         super().__init__(context, discovered_dev, CyType.MFG, scb_index, timeout)
 
     ######################################################################

--- a/src/cy_serial_bridge/utils.py
+++ b/src/cy_serial_bridge/utils.py
@@ -59,6 +59,12 @@ class DiscoveredDevice:
     # Product ID
     pid: int
 
+    # SCB index (0 or 1)
+    scb: int
+
+    # Is this a dual channel device?
+    is_dual_channel: bool
+
     # Current CyType setting (SPI, I2C, or UART)
     curr_cytype: CyType
 

--- a/tests/test_device_scan.py
+++ b/tests/test_device_scan.py
@@ -97,6 +97,9 @@ class MockUSBDeviceHandle:
     def getSerialNumber(self):
         return self.serno
 
+    def close(self):
+        return
+
 
 class MockUSBDevice(Sequence):
     """Top-level mock of usb1.USBDevice"""
@@ -219,6 +222,147 @@ CY7C65211_UART_CDC_MODE_DESCRIPTOR = MockUSBDevice(
     ],
 )
 
+# This is what a CY7C65215 looks like with both ports in UART mode
+CY7C65215_DOUBLE_UART_CDC_MODE_DESCRIPTOR = MockUSBDevice(
+    vid=0x04B4,
+    pid=0xE013,
+    handle=MockUSBDeviceHandle(manufacturer="SomeMfg", product="SomeProduct", serno="SomeSerno"),
+    configs=[
+        MockUSBConfiguration(
+            [
+                MockUSBInterface(
+                    settings=[
+                        MockUSBInterfaceSetting(
+                            class_subclass=(0x2, 0x2),
+                            endpoints=[
+                                MockUSBEndpoint(address=0x83, attributes=3),
+                            ],
+                        )
+                    ]
+                ),
+                MockUSBInterface(
+                    settings=[
+                        MockUSBInterfaceSetting(
+                            class_subclass=(0x0A, 0x00),
+                            endpoints=[
+                                MockUSBEndpoint(address=0x01, attributes=2),
+                                MockUSBEndpoint(address=0x82, attributes=2),
+                            ],
+                        )
+                    ]
+                ),
+                MockUSBInterface(
+                    settings=[
+                        MockUSBInterfaceSetting(
+                            class_subclass=(0x2, 0x2),
+                            endpoints=[
+                                MockUSBEndpoint(address=0x86, attributes=3),
+                            ],
+                        )
+                    ]
+                ),
+                MockUSBInterface(
+                    settings=[
+                        MockUSBInterfaceSetting(
+                            class_subclass=(0x0A, 0x00),
+                            endpoints=[
+                                MockUSBEndpoint(address=0x04, attributes=2),
+                                MockUSBEndpoint(address=0x85, attributes=2),
+                            ],
+                        )
+                    ]
+                ),
+                MockUSBInterface(settings=[MockUSBInterfaceSetting(class_subclass=(0xFF, 0x05), endpoints=[])]),
+            ]
+        )
+    ],
+)
+
+# This is what a CY7C65215 looks like with SCB 0 in UART mode and SCB 1 in Vendor SPI mode
+CY7C65215_UART_CDC_SPI_VENDOR_DESCRIPTOR = MockUSBDevice(
+    vid=0x04B4,
+    pid=0xE011,
+    handle=MockUSBDeviceHandle(manufacturer="SomeMfg", product="SomeProduct", serno="SomeSerno"),
+    configs=[
+        MockUSBConfiguration(
+            [
+                MockUSBInterface(
+                    settings=[
+                        MockUSBInterfaceSetting(
+                            class_subclass=(0x2, 0x2),
+                            endpoints=[
+                                MockUSBEndpoint(address=0x83, attributes=3),
+                            ],
+                        )
+                    ]
+                ),
+                MockUSBInterface(
+                    settings=[
+                        MockUSBInterfaceSetting(
+                            class_subclass=(0x0A, 0x00),
+                            endpoints=[
+                                MockUSBEndpoint(address=0x01, attributes=2),
+                                MockUSBEndpoint(address=0x82, attributes=2),
+                            ],
+                        )
+                    ]
+                ),
+                MockUSBInterface(
+                    settings=[
+                        MockUSBInterfaceSetting(
+                            class_subclass=(0xFF, 0x2),
+                            endpoints=[
+                                MockUSBEndpoint(address=0x04, attributes=2),
+                                MockUSBEndpoint(address=0x85, attributes=2),
+                                MockUSBEndpoint(address=0x86, attributes=3),
+                            ],
+                        )
+                    ]
+                ),
+                MockUSBInterface(settings=[MockUSBInterfaceSetting(class_subclass=(0xFF, 0x05), endpoints=[])]),
+            ]
+        )
+    ],
+)
+
+# This is what a CY7C65215 looks like with SCB 0 in Vendor I2C mode and SCB 1 in Vendor SPI mode
+CY7C65215_I2C_SPI_VENDOR_DESCRIPTOR = MockUSBDevice(
+    vid=0x04B4,
+    pid=0xE010,
+    handle=MockUSBDeviceHandle(manufacturer="SomeMfg", product="SomeProduct", serno="SomeSerno"),
+    configs=[
+        MockUSBConfiguration(
+            [
+                MockUSBInterface(
+                    settings=[
+                        MockUSBInterfaceSetting(
+                            class_subclass=(0xFF, 0x3),
+                            endpoints=[
+                                MockUSBEndpoint(address=0x01, attributes=2),
+                                MockUSBEndpoint(address=0x82, attributes=2),
+                                MockUSBEndpoint(address=0x83, attributes=3),
+                            ],
+                        )
+                    ]
+                ),
+                MockUSBInterface(
+                    settings=[
+                        MockUSBInterfaceSetting(
+                            class_subclass=(0xFF, 0x2),
+                            endpoints=[
+                                MockUSBEndpoint(address=0x04, attributes=2),
+                                MockUSBEndpoint(address=0x85, attributes=2),
+                                MockUSBEndpoint(address=0x86, attributes=3),
+                            ],
+                        )
+                    ]
+                ),
+                MockUSBInterface(settings=[MockUSBInterfaceSetting(class_subclass=(0xFF, 0x05), endpoints=[])]),
+            ]
+        )
+    ],
+)
+
 
 def test_scan_cy7c65211_i2c(mocker):
     """
@@ -237,6 +381,8 @@ def test_scan_cy7c65211_i2c(mocker):
             cdc_data_interface_settings=None,
             vid=0x04B4,
             pid=0xE010,
+            scb=0,
+            is_dual_channel=False,
             curr_cytype=CyType.I2C,
             open_failed=False,
             manufacturer_str="SomeMfg",
@@ -264,6 +410,8 @@ def test_scan_cy7c65211_spi(mocker):
             cdc_data_interface_settings=None,
             vid=0x04B4,
             pid=0xE010,
+            scb=0,
+            is_dual_channel=False,
             curr_cytype=CyType.SPI,
             open_failed=False,
             manufacturer_str="SomeMfg",
@@ -295,6 +443,8 @@ def test_scan_cy7c65211_uart(mocker):
             cdc_data_interface_settings=CY7C65211_UART_CDC_MODE_DESCRIPTOR[0][1][0],  # type: ignore[reportArgumentType]
             vid=0x04B4,
             pid=0xE011,
+            scb=0,
+            is_dual_channel=False,
             curr_cytype=CyType.UART_CDC,
             open_failed=False,
             manufacturer_str="SomeMfg",
@@ -302,6 +452,157 @@ def test_scan_cy7c65211_uart(mocker):
             serial_number="SomeSerno",
             serial_port_name="/dev/ttyACM1",
         )
+    ]
+
+
+def test_scan_cy7c65215_double_uart(mocker):
+    """
+    Test that we can find a CY7C65215 in double UART mode and locate the associated serial ports
+    """
+    mocker.patch("usb1.USBContext.getDeviceIterator").return_value = [CY7C65215_DOUBLE_UART_CDC_MODE_DESCRIPTOR]
+    mocker.patch("cy_serial_bridge.cy_scb_context.list_ports.comports").return_value = [
+        # Duplicate serial number used here on purpose
+        MockListPortInfo("SomeSerno", "/dev/ttyACM1"),
+        MockListPortInfo("SomeSerno", "/dev/ttyACM2"),
+        MockListPortInfo("SomeOtherSerno", "/dev/ttyACM3"),
+    ]
+
+    context = cy_serial_bridge.CyScbContext()
+    assert context.list_devices() == [
+        cy_serial_bridge.DiscoveredDevice(
+            usb_device=CY7C65215_DOUBLE_UART_CDC_MODE_DESCRIPTOR,  # type: ignore[reportArgumentType]
+            usb_configuration=CY7C65215_DOUBLE_UART_CDC_MODE_DESCRIPTOR[0],  # type: ignore[reportArgumentType]
+            mfg_interface_settings=CY7C65215_DOUBLE_UART_CDC_MODE_DESCRIPTOR[0][4][0],  # type: ignore[reportArgumentType]
+            scb_interface_settings=None,
+            usb_cdc_interface_settings=CY7C65215_DOUBLE_UART_CDC_MODE_DESCRIPTOR[0][0][0],  # type: ignore[reportArgumentType]
+            cdc_data_interface_settings=CY7C65215_DOUBLE_UART_CDC_MODE_DESCRIPTOR[0][1][0],  # type: ignore[reportArgumentType]
+            vid=0x04B4,
+            pid=0xE013,
+            scb=0,
+            is_dual_channel=True,
+            curr_cytype=CyType.UART_CDC,
+            open_failed=False,
+            manufacturer_str="SomeMfg",
+            product_str="SomeProduct",
+            serial_number="SomeSerno",
+            serial_port_name=None,
+        ),
+        cy_serial_bridge.DiscoveredDevice(
+            usb_device=CY7C65215_DOUBLE_UART_CDC_MODE_DESCRIPTOR,  # type: ignore[reportArgumentType]
+            usb_configuration=CY7C65215_DOUBLE_UART_CDC_MODE_DESCRIPTOR[0],  # type: ignore[reportArgumentType]
+            mfg_interface_settings=CY7C65215_DOUBLE_UART_CDC_MODE_DESCRIPTOR[0][4][0],  # type: ignore[reportArgumentType]
+            scb_interface_settings=None,
+            usb_cdc_interface_settings=CY7C65215_DOUBLE_UART_CDC_MODE_DESCRIPTOR[0][2][0],  # type: ignore[reportArgumentType]
+            cdc_data_interface_settings=CY7C65215_DOUBLE_UART_CDC_MODE_DESCRIPTOR[0][3][0],  # type: ignore[reportArgumentType]
+            vid=0x04B4,
+            pid=0xE013,
+            scb=1,
+            is_dual_channel=True,
+            curr_cytype=CyType.UART_CDC,
+            open_failed=False,
+            manufacturer_str="SomeMfg",
+            product_str="SomeProduct",
+            serial_number="SomeSerno",
+            serial_port_name=None,
+        ),
+    ]
+
+
+def test_scan_cy7c65215_i2c_spi(mocker):
+    """
+    Test that we can find a CY7C65215 in double UART mode and locate the associated serial ports
+    """
+    mocker.patch("usb1.USBContext.getDeviceIterator").return_value = [CY7C65215_UART_CDC_SPI_VENDOR_DESCRIPTOR]
+    mocker.patch("cy_serial_bridge.cy_scb_context.list_ports.comports").return_value = [
+        MockListPortInfo("SomeSerno", "/dev/ttyACM1"),
+        MockListPortInfo("SomeOtherSerno", "/dev/ttyACM3"),
+    ]
+
+    context = cy_serial_bridge.CyScbContext()
+    assert context.list_devices() == [
+        cy_serial_bridge.DiscoveredDevice(
+            usb_device=CY7C65215_UART_CDC_SPI_VENDOR_DESCRIPTOR,  # type: ignore[reportArgumentType]
+            usb_configuration=CY7C65215_UART_CDC_SPI_VENDOR_DESCRIPTOR[0],  # type: ignore[reportArgumentType]
+            mfg_interface_settings=CY7C65215_UART_CDC_SPI_VENDOR_DESCRIPTOR[0][3][0],  # type: ignore[reportArgumentType]
+            scb_interface_settings=None,
+            usb_cdc_interface_settings=CY7C65215_UART_CDC_SPI_VENDOR_DESCRIPTOR[0][0][0],  # type: ignore[reportArgumentType]
+            cdc_data_interface_settings=CY7C65215_UART_CDC_SPI_VENDOR_DESCRIPTOR[0][1][0],  # type: ignore[reportArgumentType]
+            vid=0x04B4,
+            pid=0xE011,
+            scb=0,
+            is_dual_channel=True,
+            curr_cytype=CyType.UART_CDC,
+            open_failed=False,
+            manufacturer_str="SomeMfg",
+            product_str="SomeProduct",
+            serial_number="SomeSerno",
+            serial_port_name="/dev/ttyACM1",
+        ),
+        cy_serial_bridge.DiscoveredDevice(
+            usb_device=CY7C65215_UART_CDC_SPI_VENDOR_DESCRIPTOR,  # type: ignore[reportArgumentType]
+            usb_configuration=CY7C65215_UART_CDC_SPI_VENDOR_DESCRIPTOR[0],  # type: ignore[reportArgumentType]
+            mfg_interface_settings=CY7C65215_UART_CDC_SPI_VENDOR_DESCRIPTOR[0][3][0],  # type: ignore[reportArgumentType]
+            scb_interface_settings=CY7C65215_UART_CDC_SPI_VENDOR_DESCRIPTOR[0][2][0],  # type: ignore[reportArgumentType]
+            usb_cdc_interface_settings=None,
+            cdc_data_interface_settings=None,
+            vid=0x04B4,
+            pid=0xE011,
+            scb=1,
+            is_dual_channel=True,
+            curr_cytype=CyType.SPI,
+            open_failed=False,
+            manufacturer_str="SomeMfg",
+            product_str="SomeProduct",
+            serial_number="SomeSerno",
+            serial_port_name=None,
+        ),
+    ]
+
+
+def test_scan_cy7c65215_uart_spi(mocker):
+    """
+    Test that we can find a CY7C65215 in double UART mode and locate the associated serial ports
+    """
+    mocker.patch("usb1.USBContext.getDeviceIterator").return_value = [CY7C65215_I2C_SPI_VENDOR_DESCRIPTOR]
+
+    context = cy_serial_bridge.CyScbContext()
+    assert context.list_devices() == [
+        cy_serial_bridge.DiscoveredDevice(
+            usb_device=CY7C65215_I2C_SPI_VENDOR_DESCRIPTOR,  # type: ignore[reportArgumentType]
+            usb_configuration=CY7C65215_I2C_SPI_VENDOR_DESCRIPTOR[0],  # type: ignore[reportArgumentType]
+            mfg_interface_settings=CY7C65215_I2C_SPI_VENDOR_DESCRIPTOR[0][2][0],  # type: ignore[reportArgumentType]
+            scb_interface_settings=CY7C65215_I2C_SPI_VENDOR_DESCRIPTOR[0][0][0],  # type: ignore[reportArgumentType]
+            usb_cdc_interface_settings=None,
+            cdc_data_interface_settings=None,
+            vid=0x04B4,
+            pid=0xE010,
+            scb=0,
+            is_dual_channel=True,
+            curr_cytype=CyType.I2C,
+            open_failed=False,
+            manufacturer_str="SomeMfg",
+            product_str="SomeProduct",
+            serial_number="SomeSerno",
+            serial_port_name=None,
+        ),
+        cy_serial_bridge.DiscoveredDevice(
+            usb_device=CY7C65215_I2C_SPI_VENDOR_DESCRIPTOR,  # type: ignore[reportArgumentType]
+            usb_configuration=CY7C65215_I2C_SPI_VENDOR_DESCRIPTOR[0],  # type: ignore[reportArgumentType]
+            mfg_interface_settings=CY7C65215_I2C_SPI_VENDOR_DESCRIPTOR[0][2][0],  # type: ignore[reportArgumentType]
+            scb_interface_settings=CY7C65215_I2C_SPI_VENDOR_DESCRIPTOR[0][1][0],  # type: ignore[reportArgumentType]
+            usb_cdc_interface_settings=None,
+            cdc_data_interface_settings=None,
+            vid=0x04B4,
+            pid=0xE010,
+            scb=1,
+            is_dual_channel=True,
+            curr_cytype=CyType.SPI,
+            open_failed=False,
+            manufacturer_str="SomeMfg",
+            product_str="SomeProduct",
+            serial_number="SomeSerno",
+            serial_port_name=None,
+        ),
     ]
 
 


### PR DESCRIPTION
This PR adds support to the scanning code for dual-channel devices. It's now smart enough to detect each SCB of dual-channel devs as a device that can be opened. It should be able to handle all possible combinations of SCB 0 and 1 descriptors, at least for modes that cy-serial-bridge supports operating in.

With this PR merged, it should now be possible to open and use each channel of a dual channel device as desired. However, I have not started on reconfiguring such devices, as I suspect this may require significant reverse engineering of their control block format and/or the USB requests to access it (they only have one manufacturer interface, not one for each port, so not quite sure how that works).

This PR was made possible via @runger1101001 graciously sending me a CY7C65215 board to test with!